### PR TITLE
Move devtmpfs mountpoint to target rootfs

### DIFF
--- a/docs/source/boot.rst
+++ b/docs/source/boot.rst
@@ -67,14 +67,18 @@ EI is generated from a template found in ``rxos/initramfs/init.in.sh`` file.
 The sources are thoroughly documented, so if you need to know more than what's
 presented here, you are welcome to peruse the sources.
 
-EI starts between 3 and 5 seconds after kernel starts booting. It mounts the SD
-card in order to access root filesystem images. There are three possible
-candidates for the final userspace, and those are ``root.sqfs``,
+EI starts between 3 and 5 seconds after kernel starts booting. 
+
+It first mounts devtmpfs to ``/dev`` so that device nodes are accessible. It
+then mounts the SD card in order to access root filesystem images. There are
+three possible candidates for the final userspace, and those are ``root.sqfs``,
 ``backup.sqfs``, and ``factory.sqfs``. These images are LZ4-compressed SquashFS
 images that contain the userspace executables, code, and data.
 
 A RAM disk with size configurable at build-time (default is 80 MiB) is created
-to serve as a write-enabled overlay over the read-only root filesystem. 
+to serve as a write-enabled overlay over the read-only root filesystem. The
+mount points for the SD card and devtmpfs are moved to ``/boot`` and ``/dev``
+in the target rootfs, respectively.
 
 For each candidate root filesystem, EI mounts the image, and creates a write
 overlay using Overlay FS and the previously configured RAM disk. It then

--- a/rxos/initramfs/init.in.sh
+++ b/rxos/initramfs/init.in.sh
@@ -73,16 +73,20 @@ mount_root() {
 #
 # Create the boot partition mount point in the target root filesystem, and move
 # the SD card mount point to the new location.
+#
+# Also move the devtmpfs mount point into the root mount point.
 set_up_boot() {
-  $MKDIR -p /mnt/root/boot
-  $MOUNT --move /mnt/sdcard /mnt/root/boot
+  $MKDIR -p /root/boot /root/dev
+  $MOUNT --move /sdcard /root/boot
+  $MOUNT --move /dev /root/dev
 }
 
 # Unount the root filesystem and related mounts
 undo_root() {
-  $UMOUNT /mnt/root/boot 2>/dev/null
-  $UMOUNT /mnt/root 2>/dev/null
-  $UMOUNT /mnt/rootfs 2>/dev/null
+  $UMOUNT /root/boot 2>/dev/null
+  $UMOUNT /root/dev 2>/dev/null
+  $UMOUNT /root 2>/dev/null
+  $UMOUNT /rootfs 2>/dev/null
 }
 
 ###############################################################################
@@ -137,6 +141,7 @@ fi
 for rootfs_image in $ROOT_IMAGES; do
   if mount_root "$rootfs_image"; then
     echo "Attempt boot $rootfs_image"
+    set_up_boot
     exec $SWITCH_ROOT /root /sbin/init $@
   fi
   # If we git this far, it means switch_root failed. We undo the set-up


### PR DESCRIPTION
When kernel boots it will not automatically mount devtmpfs if there is an
initramfs. The init script will mount it, but it did not move the mount point
into the target rootfs making some weird noises during boot.

This patch fixes the issue, and also restores the previously unused and broken
`setup_boot` function.

The documentation is also updated to reflect the changes.

Fixes #28 