### PR TITLE
Set system-wide environment before init

### DIFF
--- a/rxos/rootfs/etc/init.d/rcS
+++ b/rxos/rootfs/etc/init.d/rcS
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Start all init scripts in /etc/init.d executing them in lexical order.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+. /etc/profile
+
+for script in /etc/init.d/S??*; do
+  [ -f "$script" ] || continue
+  $script start
+done

--- a/rxos/rootfs/etc/profile.d/locale.sh
+++ b/rxos/rootfs/etc/profile.d/locale.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# System locale.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+export LANG=en_US.UTF-8


### PR DESCRIPTION
This patch adds a customized rcS script that sources /etc/profile before
running init scripts, thus allowing custom profile.d files to serve as init
configuration.

A profile.d script is added that sets the LANG environment variable.