### PR TITLE
Add trailing slash to error page prefix

### DIFF
--- a/rxos/local/lighttpd-config/src/lighttpd.conf
+++ b/rxos/local/lighttpd-config/src/lighttpd.conf
@@ -36,7 +36,7 @@ server.follow-symlink = "enable"
 server.tag = "%SERVER_TAG%"
 server.errorlog-use-syslog = "enable"
 server.accesslog-filename = "/dev/null"
-server.errorfile-prefix = server_root
+server.errorfile-prefix = server_root + "/"
 
 index-file.names = ( )
 


### PR DESCRIPTION
The Lighttpd error page prefix is treated as a string, not path, so missing
traling slashes are not handled. This commit adds the trailing slash so the
custom error pages work.

Fixes #59 