### PR TITLE
Perform fsck on boot partition in early userspace

### DIFF
--- a/rxos/local/ramfsinit/src/init.cpio.in
+++ b/rxos/local/ramfsinit/src/init.cpio.in
@@ -7,6 +7,7 @@ file /lib/ld-%LIBC_VER%.so %PREFIX%/lib/ld-%LIBC_VER%.so 755 0 0
 slink /lib/ld-linux-armhf.so.3 ld-%LIBC_VER%.so 777 0 0
 file /lib/libc-%LIBC_VER%.so %PREFIX%/lib/libc-%LIBC_VER%.so 755 0 0
 slink /lib/libc.so.6 libc-%LIBC_VER%.so 777 0 0
+file /bin/fsck.vfat %PREFIX%/sbin/fsck.vfat 755 0 0
 
 nod /dev/console 644 0 0 c 5 1
 file /bin/busybox %PREFIX%/bin/busybox 755 0 0


### PR DESCRIPTION
The FAT32 partition on the SD card is almost guaranteed to get corrupted when
power is yanked. This seems to happen regardless of whether there are writes
going to the partition or not. To handle the corruption, this commit adds
`fsck.vfat` to the initramfs image, and modifies the init script so that it
performs fsck on the boot partition, removes any .REC files that are created by
fsck, and remounts the partition read-only.

Fixes #74 