### PR TITLE
Fix lighttpd multialias configuration

### DIFF
--- a/rxos/local/lighttpd-config/src/lighttpd.conf
+++ b/rxos/local/lighttpd-config/src/lighttpd.conf
@@ -42,7 +42,7 @@ index-file.names = ( )
 
 alias.url = ( "/favicon.ico" => static_dir + "%FAVICON%" )
 alias.url += ( "/static/" => static_dir )
-alias.url += ( "/direct/" => ("%EXTERNALDIR%", "%INTERNALDIR%") )
+alias.url += ( "/direct/" => ("%EXTERNALDIR%/", "%INTERNALDIR%/") )
 $HTTP["url"] !~ "^/((direct|static)/.*)|favicon.ico" {
     proxy.server = ( "/" =>
         ( ( 


### PR DESCRIPTION
The Lighttpd aliases were missing the trailing slash causing 404 errors for
/direct/ URLs. This patch fixes the configuration file template.