### PR TITLE
Make /direct/ URL downloadable

### DIFF
--- a/rxos/local/lighttpd-config/src/lighttpd.conf
+++ b/rxos/local/lighttpd-config/src/lighttpd.conf
@@ -43,6 +43,9 @@ index-file.names = ( )
 alias.url = ( "/favicon.ico" => static_dir + "%FAVICON%" )
 alias.url += ( "/static/" => static_dir )
 alias.url += ( "/direct/" => ("%EXTERNALDIR%/", "%INTERNALDIR%/") )
+$HTTP["url"] =~ "^/direct/.+" {
+    setenv.add-response-header = ( "Content-Disposition" => "attachment" )
+}
 $HTTP["url"] !~ "^/((direct|static)/.*)|favicon.ico" {
     proxy.server = ( "/" =>
         ( ( 

--- a/rxos/local/lighttpd-config/src/modules.conf
+++ b/rxos/local/lighttpd-config/src/modules.conf
@@ -11,4 +11,5 @@ server.modules = (
   "mod_access",
   "mod_proxy",
   "mod_multialias",
+  "mod_setenv",
 )


### PR DESCRIPTION
Modern browsers usually do not try to download files they can render (e.g.,
video, audio, images, text), when pointed to them using a direct URL. To force
browsers to download, Content-Disposition header is needed. This patch changes
the lighty configuration such that the Content-Disposition header is added to
all /direct/ URLs. As a result, the download button in the UI has a more
natural behavior.