### PR TITLE
Fix lftp blacklists

### DIFF
--- a/rxos/local/librarian-config/src/librarian.ini
+++ b/rxos/local/librarian-config/src/librarian.ini
@@ -112,5 +112,17 @@ basepaths =
     %PRIMARY%
     %SECONDARY%
 
-+blacklist =
+blacklist =
+  ^\.Trash.*
+  \.fseventsd
+  \.Spotlight-V100
+  .*/?\.DS_Store
+  \._.*
+  \.TemporaryItems
+  \$RECYCLE\.BIN
+  Recycler
+  System Volume Information
+  .*/?Thumbs\.db
+  .*/?\.thumbs
+  ^lost\+found(\/.*)?$
 %BLACKLIST%


### PR DESCRIPTION
Since Librarian does not support extending component options in the main
config, this patch copies the defaults from the component config file and
prepends to the blacklist specified by rxOS build config.