### PR TITLE
Use nc for accessing sockets

### DIFF
--- a/rxos/local/storage-hotplug/Config.in
+++ b/rxos/local/storage-hotplug/Config.in
@@ -8,6 +8,7 @@ config BR2_PACKAGE_STORAGE_HOTPLUG
 	select BR2_PACKAGE_E2FSPROGS_FSCK
 	select BR2_PACKAGE_E2FSPROGS_E2FSCK
 	select BR2_PACKAGE_LED_CONTROL
+	select BR2_PACKAGE_NETCAT
 	help
 	  Enable storage hotplugging.
 

--- a/rxos/local/storage-hotplug/src/hotplug.storage.sh
+++ b/rxos/local/storage-hotplug/src/hotplug.storage.sh
@@ -75,13 +75,13 @@ get_mpoint() {
 set_ondd_path() {
   path="$1"
   printf '<put uri="/output"><path>%s</path></put>\0' "$path" \
-    > "$ONDD_SOCKET"
+    | nc "local:$ONDD_SOCKET"
 }
 
 # Request FSAL index refresh
 fsal_refresh() {
   printf '<request><command><type>refresh</type></command></request>\0' \
-    > "$FSAL_SOCKET"
+    | nc "local:$FSAL_SOCKET"
 }
 
 # Return true if filesystem is supported


### PR DESCRIPTION
This patch fixes the hotplug script so that it uses netcat when communicating
with ONDD and FSAL via their sockets.