### PR TITLE
Only add Content-Disposition to real download URLs

### DIFF
--- a/rxos/local/lighttpd-config/src/lighttpd.conf
+++ b/rxos/local/lighttpd-config/src/lighttpd.conf
@@ -44,7 +44,9 @@ alias.url = ( "/favicon.ico" => static_dir + "%FAVICON%" )
 alias.url += ( "/static/" => static_dir )
 alias.url += ( "/direct/" => ("%EXTERNALDIR%/", "%INTERNALDIR%/") )
 $HTTP["url"] =~ "^/direct/.+" {
-    setenv.add-response-header = ( "Content-Disposition" => "attachment" )
+    $HTTP["querystring"] == "dl=1" {
+        setenv.add-response-header = ( "Content-Disposition" => "attachment" )
+    }
 }
 $HTTP["url"] !~ "^/((direct|static)/.*)|favicon.ico" {
     proxy.server = ( "/" =>


### PR DESCRIPTION
Because the direct URls are used in iframes, and other places, and not just for
the download link, the Content-Disposition header may interfere with normal
operation. This patch limits the addition of Content-Disposition to only the
/direct/ URLs that have a dl=1 query string. It is expected that the
application will make use of this to specify which links should have a
Content-Disposition header.