### PR TITLE
Remove netcat dependency from storage hotplug

### DIFF
--- a/rxos/local/storage-hotplug/Config.in
+++ b/rxos/local/storage-hotplug/Config.in
@@ -8,7 +8,6 @@ config BR2_PACKAGE_STORAGE_HOTPLUG
 	select BR2_PACKAGE_E2FSPROGS_FSCK
 	select BR2_PACKAGE_E2FSPROGS_E2FSCK
 	select BR2_PACKAGE_LED_CONTROL
-	select BR2_PACKAGE_NETCAT
 	help
 	  Enable storage hotplugging.
 


### PR DESCRIPTION
The storage hotplug requires netcat to communicate with ONDD and FSAL. This
commit removes dependency on the netcat package as busybox should already be
providing netcat.