### PR TITLE
Do not strctly depend on Python 3

### DIFF
--- a/rxos/local/ramfsinit/src/dedupe_cpio.py
+++ b/rxos/local/ramfsinit/src/dedupe_cpio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Removes duplicate paths from initramfs list file.
 #


### PR DESCRIPTION
The dedupe script in the ramfsinit local package used python3 in the shebang,
but it does nothing pythhon3-specific. This patch changes the shebang to use
genric python so it can be used with python2.