### PR TITLE
Make LED signaling consistent

### DIFF
--- a/rxos/local/led-control/S99led
+++ b/rxos/local/led-control/S99led
@@ -11,9 +11,15 @@
 
 . /usr/lib/led_ctrl.sh
 
+reset_led() {
+  sleep 60
+  led_on
+}
+
 case "$1" in
   start)
-    led_blink 1000
+    led_very_slow_blink
+    reset_led &
     ;;
   stop)
     led_off

--- a/rxos/local/led-control/src/led_ctrl-i2c.sh
+++ b/rxos/local/led-control/src/led_ctrl-i2c.sh
@@ -14,6 +14,10 @@ CHIP="%LED_CHIP%"
 ADDR="%LED_ADDR%"
 I2C="i2cset -f -y $BUS $CHIP $ADDR"
 
+VERY_SLOW_INTERVAL=1000
+SLOW_INTERVAL=500
+FAST_INTERVAL=100
+
 kill_blink() {
   blink_pids="$(ps ax | grep '{blink}' | grep -v grep | awk '{print $1}')"
   kill -KILL $blink_pids
@@ -58,4 +62,8 @@ led_slow_blink() {
 
 led_fast_blink() {
   led_blink "$FAST_INTERVAL"
+}
+
+led_very_slow_blink() {
+  led_blink "$VERY_SLOW_INTERVAL"
 }

--- a/rxos/local/led-control/src/led_ctrl-sysfs.sh
+++ b/rxos/local/led-control/src/led_ctrl-sysfs.sh
@@ -15,6 +15,7 @@ LED_BRIGHTNESS="$LED/brightness"
 LED_DELAY_ON="$LED/delay_on"
 LED_DELAY_OFF="$LED/delay_off"
 
+VERY_SLOW_INTERVAL=1000
 SLOW_INTERVAL=500
 FAST_INTERVAL=100
 
@@ -50,4 +51,8 @@ led_slow_blink() {
 
 led_fast_blink() {
   led_blink $FAST_INTERVAL
+}
+
+led_very_slow_blink() {
+  led_blink "$VERY_SLOW_INTERVAL"
 }


### PR DESCRIPTION
The hotplug script resets the LED to on after it completes. Due to the way i2c
API works, it is not possible to reset it to blinking mode, and therefore, it's
no feasible to use blinking as default LED state. On the other hand, LED starts
in constant-on state on power-on, so we need some form of indication that would
tell us that something changed (e.g., boot completed).

This patch changes the behavior of the S99led init script such that it blinks
the LED for 60 seconds before switching back to solid-on, therefore giving
enough time for the user to notice boot has completed, while maintaining
consistent LED signaling during hotplug events.
