### PR TITLE
Fix date to Jan 1 2015 during early init

### DIFF
--- a/rxos/local/ramfsinit/src/init.nand.in.sh
+++ b/rxos/local/ramfsinit/src/init.nand.in.sh
@@ -132,6 +132,9 @@ doboot() {
 # SHOW STARTS HERE
 ###############################################################################
 
+# Set the date to a sane value
+date "2015-01-01 0:00:00"
+
 # Populate the /dev and /proc directories
 mount -t devtmpfs devtmpfs /dev
 mount -t proc proc /proc


### PR DESCRIPTION
This is to handle root cert expiry, and to have a relatively sane starting point in the absence of RTC.