### PR TITLE
Turn debug flag off to improve performance

### DIFF
--- a/rxos/local/librarian-config/src/librarian.ini
+++ b/rxos/local/librarian-config/src/librarian.ini
@@ -8,6 +8,9 @@ include =
 
 [app]
 
+# Turning the debug flag on has a performance impact as all templates prior to
+# rendering are `stat`-ed
+debug = no
 bind = %ADDR%
 port = %PORT%
 


### PR DESCRIPTION
The debug flag controls the `filesystem_checks` parameter in Mako,
which causes a `stat` call on each template prior to rendering, to
check if the timestamp on the sources have changed since the last
time they were compiled. In case the timestamps differ the template
is recompiled. For our purposes it can be safely turned off, which
does provide a significant performance boost.