### PR TITLE
Allow probing system status via CGI

### DIFF
--- a/rxos/local/lighttpd-config/src/lighttpd.conf
+++ b/rxos/local/lighttpd-config/src/lighttpd.conf
@@ -41,14 +41,19 @@ server.errorfile-prefix = server_root + "/"
 index-file.names = ( )
 
 alias.url = ( "/favicon.ico" => static_dir + "%FAVICON%" )
+alias.url += ( "/qa/" => "/usr/share/cgi/" )
 alias.url += ( "/static/" => static_dir )
 alias.url += ( "/direct/" => ("%EXTERNALDIR%/", "%INTERNALDIR%/") )
+$HTTP["url"] =~ "^/qa/.*" {
+    index-file.names = ( "index.sh" ),
+    cgi.assign = ( "" => ""  )
+}
 $HTTP["url"] =~ "^/direct/.+" {
     $HTTP["querystring"] == "dl=1" {
         setenv.add-response-header = ( "Content-Disposition" => "attachment" )
     }
 }
-$HTTP["url"] !~ "^/((direct|static)/.*)|favicon.ico" {
+$HTTP["url"] !~ "^/((direct|static|qa)/.*)|favicon.ico" {
     proxy.server = ( "/" =>
         ( ( 
             "host" => "127.0.0.1",

--- a/rxos/local/lighttpd-config/src/modules.conf
+++ b/rxos/local/lighttpd-config/src/modules.conf
@@ -12,4 +12,5 @@ server.modules = (
   "mod_proxy",
   "mod_multialias",
   "mod_setenv",
+  "mod_cgi",
 )

--- a/rxos/local/rxos-utils/Config.in
+++ b/rxos/local/rxos-utils/Config.in
@@ -1,4 +1,4 @@
-config BR2_PACKAGE_RXOS_UTILS
+menuconfig BR2_PACKAGE_RXOS_UTILS
 	bool "rxos-utils"
 	select BR2_PACKAGE_LIBCURL
 	select BR2_PACKAGE_CURL
@@ -21,5 +21,33 @@ config BR2_RXOS_UTILS_BOOTDEV
 	string
 	default "/dev/mmcblk0p1" if BR2_RAMFSINIT_SDCARD
 	default "ubi0:linux" if BR2_RAMFSINIT_NAND
+
+config BR2_RXOS_UTILS_PROCS
+	string "Processes"
+	default "hostapd dnsmasq dropbear postgres lighttpd fsal-daemon librarian ondd sdr100"
+	help
+	  The processes whose status is checked.
+
+config BR2_RXOS_UTILS_IFACES
+	string "Network interfaces"
+	default "wlan0 usb0"
+	help
+	  Network interfaces to check.
+
+config BR2_RXOS_UTILS_HOSTS
+	string "Host services"
+	default "Application:http:8000 HTTP:http:80; FTP:ftp:21"
+	help
+	  Local network services to check. The list is
+	  space-separated where each item has three
+	  parts in the following format:
+
+	      <label>:<protocol>:<port>
+
+config BR2_RXOS_UTILS_DEVNODES
+	string "Device nodes"
+	help
+	  Space-separate list of device nodes to check.
+	  Note that storage device node is always checked.
 
 endif  # BR2_PACKAGE_RXOS_UTILS

--- a/rxos/local/rxos-utils/rxos-utils.mk
+++ b/rxos/local/rxos-utils/rxos-utils.mk
@@ -9,16 +9,32 @@ RXOS_UTILS_LICENSE = GPLv3+
 RXOS_UTILS_SITE = $(BR2_EXTERNAL)/local/rxos-utils/src
 RXOS_UTILS_SITE_METHOD = local
 
+RXOS_UTILS_DEVNODES = $(call qstrip,$(BR2_RXOS_UTILS_STORAGE))
+RXOS_UTILS_DEVNODES += $(call qstrip,$(BR2_RXOS_UTILS_DEVNODES))
+
 RXOS_UTILS_STATUS_SED_CMDS += s|%LIBRARIAN_PORT%|$(call qstrip,$(BR2_LIBRARIAN_PORT))|;
 RXOS_UTILS_STATUS_SED_CMDS += s|%STORAGE_DEVICE%|$(call qstrip,$(BR2_RXOS_UTILS_STORAGE))|;
 RXOS_UTILS_STATUS_SED_CMDS += s|%PARTITIONS%|$(call qstrip,$(BR2_RXOS_UTILS_PARTITIONS))|;
+RXOS_UTILS_STATUS_SED_CMDS += s|%IFACES%|$(foreach iface,$(call qstrip,$(BR2_RXOS_UTILS_IFACES)),\n$(iface))|;
+RXOS_UTILS_STATUS_SED_CMDS += s|%PROCS%|$(foreach proc,$(call qstrip,$(BR2_RXOS_UTILS_PROCS)),\n$(proc))|;
+RXOS_UTILS_STATUS_SED_CMDS += s|%HOSTS%|$(foreach host,$(call qstrip,$(BR2_RXOS_UTILS_HOSTS)),\n$(host))|;
+RXOS_UTILS_STATUS_SED_CMDS += s|%DEVNODES%|$(foreach node,$(RXOS_UTILS_DEVNODES),\n$(node))|;
 RXOS_UTILS_BOOTMODE_SED_CMDS += s|%BOOTDEV%|$(call qstrip,$(BR2_RXOS_UTILS_BOOTDEV))|;
 
 define RXOS_UTILS_INSTALL_TARGET_CMDS
 	$(SED) '$(RXOS_UTILS_STATUS_SED_CMDS)' $(@D)/status.sh
 	$(SED) '$(RXOS_UTILS_BOOTMODE_SED_CMDS)' $(@D)/chbootfsmode.sh
-	$(INSTALL) -Dm0755 $(@D)/service.sh $(TARGET_DIR)/usr/sbin/service
-	$(INSTALL) -Dm0755 $(@D)/status.sh $(TARGET_DIR)/usr/bin/status
+
+	$(INSTALL) -dm0755 $(TARGET_DIR)/usr/share/cgi/
+	$(INSTALL) -Dm644 $(@D)/common.sh $(TARGET_DIR)/usr/share/cgi/common.sh
+	$(INSTALL) -Dm755 $(@D)/index.sh $(TARGET_DIR)/usr/share/cgi/index.sh
+	$(INSTALL) -Dm755 $(@D)/check.sh $(TARGET_DIR)/usr/share/cgi/check
+	$(INSTALL) -Dm755 $(@D)/top.sh $(TARGET_DIR)/usr/share/cgi/top
+	$(INSTALL) -Dm755 $(@D)/net.sh $(TARGET_DIR)/usr/share/cgi/net
+	$(INSTALL) -Dm755 $(@D)/mount.sh $(TARGET_DIR)/usr/share/cgi/mount
+
+	$(INSTALL) -Dm755 $(@D)/status.sh $(TARGET_DIR)/usr/bin/status
+	$(INSTALL) -Dm755 $(@D)/service.sh $(TARGET_DIR)/usr/sbin/service
 	$(INSTALL) -Dm0755 $(@D)/chbootfsmode.sh \
 		$(TARGET_DIR)/usr/sbin/chbootfsmode
 endef

--- a/rxos/local/rxos-utils/src/check.sh
+++ b/rxos/local/rxos-utils/src/check.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Echo system status check information
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+. /usr/share/cgi/common.sh
+
+/usr/bin/status

--- a/rxos/local/rxos-utils/src/common.sh
+++ b/rxos/local/rxos-utils/src/common.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Common headers for CGI scripts
+# 
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+echo "Content-Type: text/plain"                                                                                                                                                 
+echo "Date: $(date -R)"                                                                                                                                                         
+echo "Last-Modified: $(date -R)"                                                                                                                                                
+echo "Cache-Control: no-store"                                                                                                                                                  
+echo

--- a/rxos/local/rxos-utils/src/index.sh
+++ b/rxos/local/rxos-utils/src/index.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Create a HTML index of all CGI scripts.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+TITLE="rxOS diagnostics tools"
+
+echo 'Content-Type: text/html'
+echo 'Date: $(date -R)'
+echo 'Last-Modified: $(date -R)'
+echo
+
+echo "<html>"
+echo "<head><title>$TITLE</title></head>"
+echo "<body>"
+echo "<h1>$TITLE</h1>"
+echo "<ul>"
+for f in $(ls /usr/share/cgi | grep -v .sh); do
+  echo "<li><a href=\"$f\">$f</a></li>"
+done
+echo "</ul>"
+echo "</body>"
+echo "</html>"

--- a/rxos/local/rxos-utils/src/mount.sh
+++ b/rxos/local/rxos-utils/src/mount.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Echo mounts
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+. /usr/share/cgi/common.sh
+
+cat /proc/mounts
+echo
+df -h

--- a/rxos/local/rxos-utils/src/net.sh
+++ b/rxos/local/rxos-utils/src/net.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Echo network interface information
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+. /usr/share/cgi/common.sh
+
+ifconfig
+echo
+ip addr
+echo
+ip route

--- a/rxos/local/rxos-utils/src/top.sh
+++ b/rxos/local/rxos-utils/src/top.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Echo top output
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the 
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+. /usr/share/cgi/common.sh
+
+top -bn1


### PR DESCRIPTION
This commit sets up a new path for lighttpd at /qa/, which allows running CGI
scripts in /usr/share/cgi/. The commit also includes an assortment of CGI
scripts including:

- check : run the status command in brief mode
- top : echo complete output of the top command
- mount : echo mount points
- net : echo network information

The status script has been reworked and now features configurable tests (via
Kconfig), verbose and non-verbose (brief) mode, and a switch to enable echoing
of successful tests (by default it only outputs failed checks now).