### PR TITLE
Run demod in screen to allow access to the debug UI

### DIFF
--- a/rxos/local/sdr-config/Config.in
+++ b/rxos/local/sdr-config/Config.in
@@ -1,5 +1,6 @@
 menuconfig BR2_PACKAGE_SDR_CONFIG
 	bool "SDR init script and configuration"
+	select BR2_PACKAGE_SCREEN
 	help
 	  Install SDR demodulator configuration and 
 	  init script.

--- a/rxos/local/sdr-config/S90sdr
+++ b/rxos/local/sdr-config/S90sdr
@@ -9,14 +9,16 @@
 # (c) 2016 Outernet Inc
 # Some rights reserved.
 
-DAEMON=%BINPATH%
+DAEMON="/usr/bin/screen"
+SDR="%BINPATH%"
 JSON_PATH="%JSON_PATH%"
 PID_FILE=/var/run/sdr.pid
-DAEMON_ARGS="$(/usr/sbin/sdrargs "$JSON_PATH")"
+SDR_ARGS="$(/usr/sbin/sdrargs "$JSON_PATH")"
+DAEMON_ARGS="-T vt100 -dmS sdr $SDR $SDR_ARGS"
 RESET_PAUSE=900  # seconds
 
-[ -x "$DAEMON" ] || exit 0
-[ -z "$DAEMON_ARGS" ] && exit 0
+[ -x "$SDR" ] || exit 0
+[ -z "$SDR_ARGS" ] && exit 0
 
 pre_start() {
   # Unload modules because demod does not like it
@@ -27,8 +29,7 @@ pre_start() {
 start() {
   printf "Starting SDR demodulator: "
   pre_start
-  start-stop-daemon -S -q -m -b -p "$PID_FILE" --exec "$DAEMON" \
-    -- $DAEMON_ARGS
+  start-stop-daemon -Sqmp "$PID_FILE" -x "$DAEMON" -- $DAEMON_ARGS
   if [ $?  ]; then
     echo "OK"
   else
@@ -38,7 +39,7 @@ start() {
 
 stop() {
   printf "Stopping SDR demodulator: "
-  start-stop-daemon -K -q -p "$PID_FILE"
+  start-stop-daemon -Kqp "$PID_FILE" -x "$DAEMON"
   if [ $?  ]; then
     echo "OK"
   else

--- a/rxos/local/sdr-config/sdr-config.mk
+++ b/rxos/local/sdr-config/sdr-config.mk
@@ -15,6 +15,7 @@ SDR_CONFIG_SED_CMDS += s|%JSON_PATH%|$(call qstrip,$(BR2_LIBRARIAN_SETTINGS_FILE
 define SDR_CONFIG_INSTALL_TARGET_CMDS
 	$(INSTALL) -Dm755 $(@D)/sdrargs.py $(TARGET_DIR)/usr/sbin/sdrargs
 	$(INSTALL) -Dm755 $(@D)/ontimeout.sh $(TARGET_DIR)/usr/sbin/ontimeout
+	$(INSTALL) -Dm755 $(@D)/sdr.sh $(TARGET_DIR)/usr/sbin/sdr
 endef
 
 define SDR_CONFIG_INSTALL_INIT_SYSV

--- a/rxos/local/sdr-config/src/sdr.sh
+++ b/rxos/local/sdr-config/src/sdr.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Reattach to the demodulator running inside a sreen session.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+# 
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+SCROLLBACK=6000
+
+while getopts "n" opt; do
+  case "$opt" in
+    n)
+      NONAG=y
+      ;;
+  esac
+done
+
+if [ "$NONAG" != y ]; then
+  cat <<EOF
+You are about to start the demodulator debug interface.
+Use Ctrl+A Ctrl+D combination to detatch from it.
+
+To skip this message next time, start this script as:
+
+  $0 -n
+
+Press any key to continue...
+EOF
+  read -n1
+fi
+
+TERM=vt100 sudo screen -A -h "$SCROLLBACK" -T vt100 -D -r sdr


### PR DESCRIPTION
This patch changes the sdr init script such that the sdr binary is started in a
screen session rather than directly. This allows the debug curses UI to be
accessible while the demod is running. This also makes the sdr-config local
package to depend on screen.

A utility script, 'sdr', is provided to allow quick access to the debug UI.