### PR TITLE
Add script for creating overlay updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /docs/build
 *.pem
 /user*.mk
+/.password

--- a/docs/source/building_images/rootfs_overlays.rst
+++ b/docs/source/building_images/rootfs_overlays.rst
@@ -50,15 +50,61 @@ Finally, we adjust the ownership of the directories::
 We are now ready to create the SquashFS image::
 
     $ cd ..  # Exit overlay directory
-    $ mksquashfs overlay/ overlay-hello.sqfs -comp lz4 -Xhc
+    $ mksquashfs overlay/ overlay-hello-1.0.sqfs -comp lz4 -Xhc
 
-The output file name must be named ``overlay-<name>.sqfs`` because that is the
-pattern that the init script looks for.
+The output file name must be named ``overlay-<name>-<version>.sqfs`` because
+that is the pattern that the init script looks for. The ``name`` should not
+contain any dashes or spaces. The ``version`` can be in the X.Y or X.Y.Z format
+and the following suffixes are supported:
+
+- aN - alpha version N
+- bN - beta version N
+- rcN - release candidate N
+
+Here are some examples of valid version numbers:
+
+- 1.0a2 - second alpha version for 1.0 release
+- 2.0b1 - first beta version for 2.0 release
+- 3.1 - third major, fist minor release
+- 1.3.002 - first major, third minor, second patch release
+- 5.1rc2 - second release candidate for 5.1 release
 
 Booting with an overlay
 -----------------------
 
-To boot with an overlay, simply put the overlay file on the SD card, and boot.
+To create an image that includes overlays, put them in
+``out/images/sdcard-extras`` directory for SD card builds (e.g., Raspberry Pi), 
+and ``out/imags/overlays`` for NAND builds (e.g., CHIP).
 
-To add the overlay to the build-generated SD card image, put it in
-``out/images/sdcard-extras``.
+To install an overlay to a running system, upload the overlay to the receiver,
+and then::
+
+    $ sudo chbootfsmode
+    $ sudo mv <path/to/overlay> /boot
+    $ sudo chbootfsmode
+    $ sudo reboot
+
+Creating update packages for overlays
+-------------------------------------
+
+The ``tools`` directory contains a script called ``mkoverlaypkg.sh``. This
+script will create an OTA update ``.pkg`` file for any overlay images found in
+``out/images/overlays``. Run the script with ``-h`` flag to see the options it
+supports.
+
+The generated overlay files have the following naming convention::
+
+    rxos-<platform version>-overlay-<name>-<version>-<timestamp><suffix>.pkg
+
+- ``platform version`` can be a version of a rxOS release (e.g., v1.0) or
+  ``any``. If the version is specified, the update package can only be
+  installed on that particular version of rxOS.
+- ``name`` is the overlay name, and only overlays that have the same name that
+  are *already installed* are going to be updated by the generated upate
+  package
+- ``version`` is the overlay version, and if version check is enabled (see
+  ``suffix`` below), only overlays that are newer than the already installed
+  overlay are upgraded
+- ``timestamp`` is a timestamp in local time, when overlay package was created
+- ``suffix`` can be either a blank string or ``nv``, for non-version-checking
+  package

--- a/tools/mkoverlaypkg.sh
+++ b/tools/mkoverlaypkg.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#
+# Create OTA update packages for overlays in the output directory.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+# 
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+
+set -e
+
+SCRIPTDIR=$(dirname $0)
+SRCDIR="${SCRIPTDIR}/.."
+OUTDIR="${SRCDIR}/out"
+BINDIR="${OUTDIR}/images"
+HOSTDIR="${OUTDIR}/host"
+TARGETDIR="${OUTDIR}/target"
+MKPKG="${HOSTDIR}/usr/bin/mkpkg"
+SIGNATURE="${BINDIR}/signature.pem"
+PWFILE="${SRCDIR}/.password"
+VERFILE="${TARGETDIR}/etc/version"
+VERSION="$(cat "$VERFILE")"
+INSTALLER_SRC="${SCRIPTDIR}/overlay-installer.in.sh"
+
+fail() {
+  msg="$*"
+  echo "ERROR: $msg"
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: $0 [-P]
+
+Options:
+
+  -h    show this message and exit
+  -P    do not perform target platform version check
+  -I    ignore any installed version and always overwrite
+
+Details:
+
+  When installer runs, by default it checks the platform version
+  of the receiver to determine overlay compatibility. This behavior
+  can be suppressed by using the -P option.
+EOF
+}
+
+get_overlay_name() {
+  local overlay_basename="$1"
+  echo "$overlay_basename" | cut -d- -f2
+}
+
+get_overlay_version() {
+  local overlay_basename="$1"
+  echo "$overlay_basename" | cut -d- -f3
+}
+
+package_overlay() {
+  local overlay_file="$1"
+  local overlay_filename
+  local overlay_basename
+  local overlay_name
+  local overlay_version
+  local installer_out
+  local pkgfile
+  local timestamp
+  local version
+  local sed_xpr
+  local suffix
+
+  # GEt all the variables
+  echo "Packaging overlay $overlay_file"
+  overlay_filename=$(basename "$overlay_file")""
+  overlay_basename="${overlay_filename%%.sqfs}"
+  overlay_name=$(get_overlay_name "$overlay_basename")
+  overlay_version=$(get_overlay_version "$overlay_basename")
+  installer_out="$(mktemp -t overlay-installer-XXXX.sh)"
+
+  # Create the installer script
+  sed_xpr="
+  s|%OVERLAY_FILE%|${overlay_filename}|;
+  s|%OVERLAY_NAME%|${overlay_name}|;
+  s|%TARGET_VERSION%|${TARGET_VERSION}|;"
+  if [ "$IGNORE_VERSION" = y ]; then
+    sed_xpr="$sed_xpr s|%OVERLAY_VERSION%||;"
+    suffix="nv"
+  else
+    sed_xpr="$sed_xpr s|%OVERLAY_VERSION%|${overlay_version}|;"
+  fi
+  sed -e  "$sed_xpr" > "$installer_out" < "$INSTALLER_SRC"
+
+  # Create the .pkg file
+  if [ "$TARGET_VERSION" = any ]; then
+    version=any
+  else
+    version="v${TARGET_VERSION}"
+  fi
+  timestamp="$(date '+%Y%m%d%H%M')"
+  pkgfile="$BINDIR/rxos-${version}_overlay-${overlay_name}-v${overlay_version}-${timestamp}${suffix}.pkg"
+  chmod +x "$installer_out"
+  $MKPKG $MKPKG_ARGS -o "$pkgfile" "${installer_out}:run.sh" "${overlay_file}"
+  rm -f "$installer_out"
+}
+
+[ -x "$MKPKG" ] || fail "mkpkg not found, please complete the build first"
+
+[ -f "$SIGNATURE" ] && MKPKG_ARGS="-k $SIGNATURE"
+
+while getopts "hPI" opt; do
+  case "$opt" in
+    h)
+      usage
+      exit 0
+      ;;
+    P)
+      IGNORE_PLATFORM=y
+      ;;
+    I)
+      IGNORE_VERSION=y
+      ;;
+    *)
+      fail "invalid option $opt"
+      ;;
+  esac
+done
+
+if [ "$IGNORE_PLATFORM" != y ]; then
+  TARGET_VERSION="$VERSION"
+else
+  TARGET_VERSION="any"
+fi
+
+if [ -f "$PWFILE" ]; then
+  PASSWORD="$(cat "$PWFILE")"
+else
+  read -srp "Signature file password: " PASSWORD
+fi
+
+[ -n "$PASSWORD" ] && MKPKG_ARGS="$MKPKG_ARGS -p $PASSWORD"
+
+find "$BINDIR/overlays/" -name "overlay-*.sqfs" | while read -r overlay; do
+  package_overlay "$overlay"
+done

--- a/tools/overlay-installer.in.sh
+++ b/tools/overlay-installer.in.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+#
+# Install overlay image.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+# 
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+OVERLAY_FILE="%OVERLAY_FILE%"
+OVERLAY_NAME="%OVERLAY_NAME%"
+OVERLAY_VERSION="%OVERLAY_VERSION%"
+TARGET_VERSION="%TARGET_VERSION%"
+LOCAL_VERSION="$(cat /etc/version)"
+
+LOG="logger -s -t pkg.installer"
+
+INSTALLER="$1"
+
+fail() {
+  msg="$*"
+  $LOG "$msg"
+  mount -o remount,ro /boot
+  exit 1
+}
+
+###############################################################################
+# VERSION COMPARISON FUNCTIONS
+###############################################################################
+
+SFXMAJ_FAC=100        # suffix factor
+PAT_FAC=1000          # patch version factor
+MIN_FAC=1000000       # minor release factor
+MAJ_FAC=1000000000    # major release factor
+
+# Fnd the suffix portion of the version string
+suffix() {
+  echo "$1" | egrep -o '(a|b|rc)[0-9]+'
+}
+
+# Find the numeric portion of the version string
+mainver() {
+  echo "$1" | egrep -o '[0-9]+\.[0-9]+(\.[0-9]+)?'
+}
+
+# Convert a version number to a single integer
+normalize() {
+  ver=$(mainver "$1")
+  sfx=$(suffix "$1")
+  sfxtype=$(echo "$sfx" | egrep -o "[a-z]+")
+  sfxnum=$(echo "$sfx" | egrep -o "[0-9]+")
+  vmaj=$(echo "$ver" | cut -d. -f1)
+  vmin=$(echo "$ver" | cut -d. -f2)
+  vpat=$(echo "$ver" | cut -d. -f3)
+
+  [ -z "$vpat" ] && vpat=0
+  [ -z "$sfxnum" ] && sfxnum=1
+
+  case "$sfxtype" in
+    a)
+      sfxmaj=1
+      ;;
+    b)
+      sfxmaj=2
+      ;;
+    rc)
+      sfxmaj=3
+      ;;
+    *)
+      sfxmaj=4
+      ;;
+  esac
+
+  echo $(( MAJ_FAC * vmaj + MIN_FAC * vmin + PAT_FAC * vpat + SFXMAJ_FAC * sfxmaj + sfxnum ))
+}
+
+# Perform version comparison
+vercmp() {
+  pkg_version="$1"
+  platform_version="$2"
+  test "$(normalize "$pkg_version")" -gt "$(normalize "$platform_version")"
+}
+
+###############################################################################
+# FLASHING
+###############################################################################
+
+# Do not install on wrong platform version if target version is specified
+if [ "$TARGET_VERSION" != "any" ] && [ "$LOCAL_VERSION" != "$TARGET_VERSION" ]; then
+  fail "This overlay is for $TARGET_VERSION but $LOCAL_VERSION was found"
+fi
+
+# Find existing overlay in bootfs
+#
+# While it's technically possible to have more than one overlay of the same
+# name, we will operate on the assumption that this is not going to be the
+# case.
+#
+original=$(find /boot -name "overlay-${OVERLAY_NAME}-*.sqfs" | tail -n1)
+
+[ -z "$original" ] && fail "No overlays to update"
+
+# Get the original overlay version, perform version check
+if [ -n "$OVERLAY_VERSION" ] && [ -n "$original" ]; then
+  original_file=$(basename "$original")
+  original_version=$(echo "$original_file" | sed 's/.sqfs//' | cut -d- -f3)
+  if ! vercmp "$OVERLAY_VERSION" "$original_version"; then
+    fail "Same or newer version already installed."
+  fi
+fi
+
+$LOG "Installing $OVERLAY_NAME"
+mount -o remount,rw /boot || fail "Could not unlock boot partition"
+$LOG "Removing all backups"
+rm "/boot/overlay-${OVERLAY_NAME}-*.sqfs.backup"
+if [ -n "$original" ]; then
+  cp "$original" "${original}.backup" \
+    || fail "Could not back up ${original}"
+  sync
+fi
+if ! $INSTALLER --extract "$OVERLAY_FILE" /boot; then
+  [ -n "$original" ] && mv "${original}.backup" "${original}" && sync
+  fail "Could not extract $OVERLAY_FILE"
+fi
+sync
+mount -o remount,ro /boot
+$LOG "Installed $OVERLAY_NAME"
+
+reboot


### PR DESCRIPTION
This commit adds a utility script, tools/mkoverlaypkg.sh, which creates overlay
update packages from any overlays in the `out/images/overlays` directory. The
documentation on overlays has been updated to inludes not on using this script
and the naming of the generated package files.

See #110 