### PR TITLE
Do not persist in safemode

### DIFF
--- a/rxos/local/persist-conf/src/persist.sh
+++ b/rxos/local/persist-conf/src/persist.sh
@@ -15,6 +15,8 @@
 # (c) 2016 Outernet Inc
 # Some rights reserved.
 
+[ -f /SAFEMODE ] && exit 0
+
 CONFDIR="%CONFDIR%"
 CONFLIST="/etc/persist.conf"
 

--- a/rxos/local/ramfsinit/src/init.cpio.in
+++ b/rxos/local/ramfsinit/src/init.cpio.in
@@ -35,6 +35,7 @@ slink /bin/sed /bin/busybox 777 0 0
 slink /bin/egrep /bin/busybox 777 0 0
 slink /bin/grep /bin/busybox 777 0 0
 slink /bin/dd /bin/busybox 777 0 0
+slink /bin/touch /bin/busybox 777 0 0
 slink /bin/mount /bin/busybox 777 0 0
 slink /bin/umount /bin/busybox 777 0 0
 slink /bin/fdisk /bin/busybox 777 0 0

--- a/rxos/local/ramfsinit/src/init.nand.in.sh
+++ b/rxos/local/ramfsinit/src/init.nand.in.sh
@@ -130,6 +130,7 @@ set_up_boot() {
   mount --move /dev /root/dev
   mount --move /proc /root/proc
   mount --move /sys /root/sys
+  [ "$SAFE_MODE" = y ] && touch /root/SAFEMODE
 }
 
 # Unount the root filesystem and related mounts
@@ -193,7 +194,7 @@ echo "$SAFE_MODE_PIN" > /sys/class/gpio/export
 is_safe_mode=$(cat "/sys/class/gpio/gpio$SAFE_MODE_PIN/value")
 echo "$SAFE_MODE_PIN" > /sys/class/gpio/unexport
 if hasarg "safemode" || [ "$is_safe_mode" = 0 ]; then
-  SKIP_OVERLAYS=y
+  SAFE_MODE=y
 fi
 
 # Run setup hooks. The hooks are shell scripts that named like hook-*.sh. They
@@ -213,7 +214,7 @@ mkdir -p /tmpfs/upper /tmpfs/work
 
 # Mount overlay images if any
 mount -t ubifs -o ro ubi0:linux /linux
-if [ "$SKIP_OVERLAYS" != y ]; then
+if [ "$SAFE_MODE" != y ]; then
   for overlay in /linux/overlay-*.sqfs; do
     mount_overlay "$overlay"
   done


### PR DESCRIPTION
This patch introuces the following changes:

- When safe mode is enabled either through XIO-P0 or kernel command line, the
  early init will create an empty file called SAFEMODE in the root of the root
  filesystem
- The persist setup hook will detect the presence of SAFEMODE in the root of
  the rootfs completely skip persistence in that case exiting with 0 status

With these changes, we are now able to escape from a situation where a
malformed configuration file can cause the system to become unusable (e.g.,
wrong interfaces configuration leading to complete lack of connectivity, or
system becoming unstable due to some combination of hostapd settings).

See #125 