### PR TITLE
Change save path of uploaded firmware package through librarian

### DIFF
--- a/rxos/local/librarian-config/src/librarian.ini
+++ b/rxos/local/librarian-config/src/librarian.ini
@@ -88,3 +88,7 @@ main = %MENU%
 
 backend = in-memory
 timeout = 100
+
+[firmware]
+
+save_path = /tmp/firmware


### PR DESCRIPTION
The default path is `tmp/firmware`, changing it to `/tmp/firmware`