### PR TITLE
Fix/remote iface remove

### DIFF
--- a/rxos/local/remote-support/S11remotesetup
+++ b/rxos/local/remote-support/S11remotesetup
@@ -25,7 +25,7 @@ CONF_FILE_EXT="/mnt/external/REMOTE"
 CONF_FILE_EXT_DISABLE="/mnt/external/REMOTE_DISABLE"
 CONF_FILE="/mnt/conf/REMOTE"
 CONF_FILE_DISABLE="/mnt/conf/REMOTE.disabled"
-IFACE="eth0"
+
 
 
 configure_hostname() {
@@ -42,7 +42,6 @@ setup() {
   PORT="${PORT:=$(( RANDOM % 10000 + 20000  ))}"
   echo "REVSSH_HOST=\"$HOST\"" > /etc/conf.d/remote
   echo "REVSSH_PORT=\"$PORT\"" >> /etc/conf.d/remote
-  echo "REVSSH_IFACE=\"$IFACE\"" >> /etc/conf.d/remote
   return 0
 }
 

--- a/rxos/local/remote-support/S99remote
+++ b/rxos/local/remote-support/S99remote
@@ -20,21 +20,12 @@ REMOTE_USER="nologin"
 REMOTE_LOGIN="${REMOTE_USER}@$REVSSH_HOST"
 LOGFILE="/tmp/revssh-start.log"
 
-getip() {
-  ip addr show "$REVSSH_IFACE" | grep "inet " | awk '{print $2}' \
-    | cut -d/ -f1
-}
 
 # This function will run the SSH rev tunnel in an infinite loop and keep
 # starting it whenever it quits with a 5s delay between each start.
 revtunnel() {
   while true; do
-    ip=$(getip)
-    while [ -z "$ip" ]; do
-        sleep 2
-        ip=$(getip)
-    done
-    $DAEMON -y -i "$SSH_KEY" -R "$REVSSH_PORT:$ip:$LOCAL_PORT" -N -T \
+    $DAEMON -y -i "$SSH_KEY" -R "$REVSSH_PORT:127.0.0.1:$LOCAL_PORT" -N -T \
       "$REMOTE_LOGIN" -K 30 -I 150 >"$LOGFILE" 2>&1
     sleep $RESTART_DELAY
   done


### PR DESCRIPTION
remove dependency on selecting the right IFACE for remote, as remote does not actually need the ip of a specific IFACE to function. 127.0.0.1 (lo IFACE) works just fine in all situations.
