### PR TITLE
fix bash overflow due to large factors

### DIFF
--- a/tools/overlay-installer.in.sh
+++ b/tools/overlay-installer.in.sh
@@ -31,9 +31,9 @@ fail() {
 ###############################################################################
 
 SFXMAJ_FAC=100        # suffix factor
-PAT_FAC=1000          # patch version factor
-MIN_FAC=1000000       # minor release factor
-MAJ_FAC=1000000000    # major release factor
+PAT_FAC=100           # patch version factor
+MIN_FAC=10000         # minor release factor
+MAJ_FAC=1000000       # major release factor
 
 # Fnd the suffix portion of the version string
 suffix() {


### PR DESCRIPTION
reduce factors by 10 for each level.
right now each level is 1000, so bash overflows, as it seems it uses signed int (makes sense). 
post this fix, each level is a factor of 100, which ought to be enough for anybody - even emacs!