### PR TITLE
Add separate script that performs the restarting of the network stack

### DIFF
--- a/rxos/local/network-config/network-config.mk
+++ b/rxos/local/network-config/network-config.mk
@@ -139,6 +139,7 @@ define NETWORK_CONFIG_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/etc/network/if-up.d/check_ip_assigned
 	$(foreach ifacecmds,$(NETWORK_CONFIG_INSTALL_IFACES),$(call $(ifacecmds)))
 	$(INSTALL) -Dm755 $(@D)/wireless.sh $(TARGET_DIR)/etc/setup.d/wireless.sh
+	$(INSTALL) -Dm755 $(@D)/netrestart.sh $(TARGET_DIR)/usr/sbin/netrestart
 	$(INSTALL) -Dm755 $(@D)/S99netguard $(TARGET_DIR)/etc/init.d/S99netguard
 endef
 

--- a/rxos/local/network-config/src/S99netguard
+++ b/rxos/local/network-config/src/S99netguard
@@ -20,15 +20,6 @@ AP_MODE=AP
 STA_MODE=STA
 DHCP=dhcp
 
-# Execute necessary commands to restart the network stack
-restart_net_stack() {
-  /etc/setup.d/wireless.sh
-  ap stop
-  wpa wlan0 stop
-  service network restart
-  service dnsmasq restart
-}
-
 # Run a loop with 1 second delays, checking if IP assignment was done via
 # dhcp or not
 guard() {
@@ -46,7 +37,8 @@ guard() {
   # If it reaches this point, the wait period is reached and no IP
   # was assigned by dhcp, so revert back to AP mode
   echo "$AP_MODE" > "$WIRELESS_MODE_FILE"
-  restart_net_stack
+  # Execute script that restarts the network stack
+  /usr/sbin/netrestart
 }
 
 start() {

--- a/rxos/local/network-config/src/netrestart.sh
+++ b/rxos/local/network-config/src/netrestart.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Execute necessary commands to restart the network stack
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+reboot


### PR DESCRIPTION
Instead of containing the sequence of commands in the netguard init
script and within librarian-netinterfaces configuration, it will be
stored only in netrestart.sh