### PR TITLE
Add opakwatch package

### DIFF
--- a/rxos/Config.in
+++ b/rxos/Config.in
@@ -77,6 +77,7 @@ menu "Data services"
 endmenu
 
 menu "Applications"
+	source "$BR2_EXTERNAL/local/opakwatch/Config.in"
 	source "$BR2_EXTERNAL/local/librarian-config/Config.in"
 	source "$BR2_EXTERNAL/local/fsal-config/Config.in"
 	source "$BR2_EXTERNAL/package/python-librarian/Config.in"

--- a/rxos/local/opakwatch/Config.in
+++ b/rxos/local/opakwatch/Config.in
@@ -1,0 +1,19 @@
+menuconfig BR2_PACKAGE_OPAKWATCH
+	bool "opak file watcher and extractor"
+	select BR2_PACKAGE_INOTIFY_TOOLS
+	help
+	  Install opakwatch tool and init script.
+
+if BR2_PACKAGE_OPAKWATCH
+
+config BR2_OPAKWATCH_SOURCE
+	string "Source directory path to watch"
+	help
+	  Absolute path to a directory to be watched for new files.
+
+config BR2_OPAKWATCH_DESTINATION
+	string "Destination directory path where to extract opak archives"
+	help
+	  Absolute path to a directory where the archives will be extracted.
+
+endif

--- a/rxos/local/opakwatch/opakwatch.mk
+++ b/rxos/local/opakwatch/opakwatch.mk
@@ -1,0 +1,24 @@
+################################################################################
+#
+# opakwatch
+#
+################################################################################
+
+OPAKWATCH_VERSION = 1.0
+OPAKWATCH_LICENSE = GPLv3+
+OPAKWATCH_SITE = $(BR2_EXTERNAL)/local/opakwatch/src
+OPAKWATCH_SITE_METHOD = local
+
+OPAKWATCH_SED_CMDS += s|%OPAKSOURCE%|$(call qstrip,$(BR2_OPAKWATCH_SOURCE))|;
+OPAKWATCH_SED_CMDS += s|%OPAKDESTINATION%|$(call qstrip,$(BR2_OPAKWATCH_DESTINATION))|;
+
+define OPAKWATCH_INSTALL_TARGET_CMDS
+	$(INSTALL) -Dm755 $(@D)/opakwatch.sh $(TARGET_DIR)/usr/bin/opakwatch
+endef
+
+define OPAKWATCH_INSTALL_INIT_SYSV
+	$(INSTALL) -Dm0755 $(@D)/S99opakwatch $(TARGET_DIR)/etc/init.d/S99opakwatch
+	$(SED) '$(OPAKWATCH_SED_CMDS)' $(TARGET_DIR)/etc/init.d/S99opakwatch
+endef
+
+$(eval $(generic-package))

--- a/rxos/local/opakwatch/src/S99opakwatch
+++ b/rxos/local/opakwatch/src/S99opakwatch
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Start opakwatcher over the prespecified directories
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+SOURCE="%OPAKSOURCE%"
+DESTINATION="%OPAKDESTINATION%"
+DAEMON="/usr/bin/opakwatch"
+RESTART_DELAY="2"
+
+start() {
+  printf "Starting opakwatcher: "
+  $DAEMON $SOURCE $DESTINATION &
+  echo "OK"
+}
+
+stop() {
+  printf "Stopping opakwatcher: "
+  # There's no known PID, so we kill them by process list
+  for proc in $(ps ax | grep $DAEMON | grep -v grep | awk '{print $1}'); do
+    kill "$proc"
+  done
+  echo "OK"
+}
+
+status() {
+  ps ax | grep $DAEMON | grep -q -v grep && echo "Running" || echo "Stopped"
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    restart)
+        stop
+        sleep $RESTART_DELAY
+        start
+        ;;
+esac
+
+exit $?

--- a/rxos/local/opakwatch/src/opakwatch.sh
+++ b/rxos/local/opakwatch/src/opakwatch.sh
@@ -11,6 +11,7 @@
 # Some rights reserved.
 USAGE='opakwatch SOURCE DESTINATION'
 TAR='/bin/tar'
+ONFSCHANGE='/usr/bin/oncontentchange'
 
 if [ $# != 2 ]
 then
@@ -25,4 +26,5 @@ inotifywait -m "$SOURCE" --format '%w%f' -e create |
   while read -r filename; do
     echo "Discovered '$filename', attempting extraction..."
     $TAR xf "$filename" --directory "$DESTINATION"
+    $ONFSCHANGE
   done

--- a/rxos/local/opakwatch/src/opakwatch.sh
+++ b/rxos/local/opakwatch/src/opakwatch.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Watch the specified source folder for newly created files and
+# extract them as soon as they appear.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+USAGE='opakwatch SOURCE DESTINATION'
+TAR='/bin/tar'
+
+if [ $# != 2 ]
+then
+  echo >&2 "$USAGE"
+  exit 1
+fi
+
+SOURCE="$1"
+DESTINATION="$2"
+
+inotifywait -m "$SOURCE" --format '%w%f' -e create |
+  while read -r filename; do
+    echo "Discovered '$filename', attempting extraction..."
+    $TAR xf "$filename" --directory "$DESTINATION"
+  done

--- a/rxos/local/storage-hotplug/src/hotplug.storage.sh
+++ b/rxos/local/storage-hotplug/src/hotplug.storage.sh
@@ -29,6 +29,7 @@
 
 # Set PATH
 PATH="/bin:/usr/bin:/sbin:/usr/sbin"
+REFRESH_CMD="/usr/bin/oncontentchange"
 
 EXTERNAL_MPOINT="/mnt/external"
 NODENAME="${DEVNAME##/dev/}"
@@ -50,7 +51,6 @@ case "$ID_FS_TYPE" in
 esac
 
 ONDD_SOCKET="/var/run/ondd.ctrl"
-FSAL_SOCKET="/var/run/fsal.ctrl"
 
 # Log debug messages
 log() {
@@ -70,12 +70,6 @@ do_fsck() {
 # If the device has not been mounted, empty string is returned.
 get_mpoint() {
   egrep "^$DEVNAME" /proc/mounts | awk '{print $2;}'
-}
-
-# Request FSAL index refresh
-fsal_refresh() {
-  printf '<request><command><type>refresh</type></command></request>\0' \
-    | nc "local:$FSAL_SOCKET"
 }
 
 # Return true if filesystem is supported
@@ -193,7 +187,7 @@ add() {
 
   log "Redirecting ONDD to external storage"
   log "Refreshing file index"
-  fsal_refresh
+  $REFRESH_CMD
 
   reset_led
 }
@@ -215,7 +209,7 @@ remove() {
   revert_internal
 
   log "Refreshing file index"
-  fsal_refresh
+  $REFRESH_CMD
 
   reset_led
 }

--- a/rxos/local/storage-hotplug/src/oncontentchange.sh
+++ b/rxos/local/storage-hotplug/src/oncontentchange.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# If FSAL socket is found, it will send a command over IPC to it that will
+# trigger an index refresh.
+#
+# This file is part of rxOS.
+# rxOS is free software licensed under the
+# GNU GPL version 3 or any later version.
+#
+# (c) 2016 Outernet Inc
+# Some rights reserved.
+
+FSAL_SOCKET="/var/run/fsal.ctrl"
+
+# Noop if fsal is not available
+[ -f $FSAL_SOCKET ] || exit 0
+
+# Request FSAL index refresh
+printf '<request><command><type>refresh</type></command></request>\0' \
+  | nc "local:$FSAL_SOCKET"

--- a/rxos/local/storage-hotplug/storage-hotplug.mk
+++ b/rxos/local/storage-hotplug/storage-hotplug.mk
@@ -15,6 +15,8 @@ define STORAGE_HOTPLUG_INSTALL_TARGET_CMDS
 	sed -i '$(STORAGE_HOTPLUG_SED_CMDS)' $(@D)/hotplug.storage.sh
 	$(INSTALL) -Dm755 $(@D)/hotplug.storage.sh \
 		$(TARGET_DIR)/usr/sbin/hotplug.storage
+	$(INSTALL) -Dm755 $(@D)/oncontentchange.sh \
+		$(TARGET_DIR)/usr/bin/oncontentchange
 	$(INSTALL) -Dm644 $(@D)/99-storage.rules \
 		$(TARGET_DIR)/etc/udev/rules.d/99-storage.rules
 endef


### PR DESCRIPTION
opakwatch installs a utility script into /usr/bin/opakwatch and an init
script into /etc/init.d/S99opakwatch. When started the script will watch
a specified directory (using inotify) for newly created files and attempt
to extract them with tar to an also specified destination directory.