### PR TITLE
Autodelete

### DIFF
--- a/rxos/Config.in
+++ b/rxos/Config.in
@@ -71,6 +71,7 @@ menu "Network configuration"
 endmenu
 
 menu "Data services"
+	source "$BR2_EXTERNAL/local/cleanup/Config.in"
 	source "$BR2_EXTERNAL/local/sdr-config/Config.in"
 	source "$BR2_EXTERNAL/package/ondd/Config.in"
 	source "$BR2_EXTERNAL/package/python-fsal/Config.in"

--- a/rxos/configs/busybox.config
+++ b/rxos/configs/busybox.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.24.1
-# Tue Jul 26 16:04:58 2016
+# Wed Sep 28 18:04:04 2016
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -284,8 +284,8 @@ CONFIG_SORT=y
 CONFIG_FEATURE_SORT_BIG=y
 # CONFIG_SPLIT is not set
 # CONFIG_FEATURE_SPLIT_FANCY is not set
-# CONFIG_STAT is not set
-# CONFIG_FEATURE_STAT_FORMAT is not set
+CONFIG_STAT=y
+CONFIG_FEATURE_STAT_FORMAT=y
 CONFIG_STTY=y
 # CONFIG_SUM is not set
 # CONFIG_TAC is not set

--- a/rxos/local/cleanup/Config.in
+++ b/rxos/local/cleanup/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_CLEANUP
+	bool "cleanup.sh"
+	help
+	  Script to clean up the content and free up space
+
+	  https://outernet.is/

--- a/rxos/local/cleanup/S90cleanup
+++ b/rxos/local/cleanup/S90cleanup
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+PIDFILE="/var/run/cleanup.pid"
+CLEANUP_INTERVAL=$(( 60 * 60 ))  # 1 hour
+
+runcleanup() {
+  while true; do
+    /usr/sbin/cleanup
+    sleep $CLEANUP_INTERVAL
+  done
+}
+
+
+start() {
+  printf "Starting cleanup daemon: "
+  runcleanup &
+  if [ $? = 0 ]; then
+    echo "$!" > "$PIDFILE"
+    echo "OK"
+  else
+    echo "FAIL"
+  fi
+}
+
+stop() {
+  pid="$(cat "$PIDFILE")"
+  kill "$pid"
+}
+
+case $1 in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage $0 {start|stop|restart}"
+esac
+
+exit $?

--- a/rxos/local/cleanup/cleanup.mk
+++ b/rxos/local/cleanup/cleanup.mk
@@ -1,0 +1,21 @@
+################################################################################
+#
+# cleanup-init
+#
+################################################################################
+
+CLEANUP_VERSION = 1.0
+CLEANUP_LICENSE = GPLv3+
+CLEANUP_SITE = $(BR2_EXTERNAL)/local/cleanup/src
+CLEANUP_SITE_METHOD = local
+
+define CLEANUP_INSTALL_TARGET_CMDS
+	$(INSTALL) -Dm755 $(@D)/cleanup.sh $(TARGET_DIR)/usr/sbin/cleanup
+endef
+
+define CLEANUP_INSTALL_INIT_SYSV
+	$(INSTALL) -Dm755 $(call lpkgdir,cleanup)/S90cleanup \
+		$(TARGET_DIR)/etc/init.d/S90cleanup
+endef
+
+$(eval $(generic-package))

--- a/rxos/local/cleanup/src/cleanup.sh
+++ b/rxos/local/cleanup/src/cleanup.sh
@@ -8,7 +8,7 @@ DLDIR=/mnt/internal
 AVAIL="$(df -P "$DLDIR" | tail -n1 | awk '{print $4}')"  # KiB
 MINFREE=$(( 200 * MiB ))  # OTA update 100 MiB + data 100 MiB
 NEEDS="$(( MINFREE - AVAIL ))"  # KiB
-CALLBACK="/usr/sbin/oncontentchange.sh"
+CALLBACK="/usr/bin/oncontentchange.sh"
 LOG="logger -t cleanup"
 
 if [ "$NEEDS" -le 0 ]; then

--- a/rxos/local/cleanup/src/cleanup.sh
+++ b/rxos/local/cleanup/src/cleanup.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+KiB=1  # Base unit is KiB
+MiB=$(( 1024 * KiB ))
+GiB=$(( 1024 * MiB ))
+
+DLDIR=/mnt/internal
+AVAIL="$(df -P "$DLDIR" | tail -n1 | awk '{print $4}')"  # KiB
+MINFREE=$(( 200 * MiB ))  # OTA update 100 MiB + data 100 MiB
+NEEDS="$(( MINFREE - AVAIL ))"  # KiB
+CALLBACK="/usr/sbin/oncontentchange.sh"
+LOG="logger -t cleanup"
+
+if [ "$NEEDS" -le 0 ]; then
+  $LOG "Needs $MINFREE KiB, but there is already $AVAIL KiB, nothing to do"
+  exit 0
+fi
+
+$LOG "Cleanup needs to free $NEEDS KiB"
+
+filestats() {
+  find "$DLDIR" -type f -exec stat -c '%Y|%s|%n' "{}" +
+}
+
+sort_by_ts() {
+  sort -n -t\| -k1
+}
+
+size_freed=0
+count=0
+
+filestats | sort_by_ts | while read file; do
+  if [ "$size_freed" -ge "$NEEDS" ]; then
+    sync
+    $LOG "Removed $count files and freed $size_freed KiB"
+    break
+  fi
+
+  size="$(echo "$file" | cut -d\| -f2)"
+  size="$(( size / 1024 ))"
+  path="$(echo "$file" | cut -d\| -f3)"
+
+  rm -f "$path"
+  $LOG "Removed '$path' to free $size KiB"
+  size_freed="$(( size_freed + size ))"
+  count="$(( count + 1 ))"
+done
+
+[ -x "$CALLBACK" ] && "$CALLBACK"


### PR DESCRIPTION
This patch adds a new local package called 'cleanup', which installs a 'S90cleanup' service and a cleanup script that is configured to ensure 200 MiB of free space on `/mnt/internal`. Note that this script only cleans up the *internal storage* so as to prevent accidental deletion of user files on external storage. 

The package is currently not buildroot-configurable in terms of operating parameters.